### PR TITLE
parseAmountFromString() works with '1E8' but not with '1e8'

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -122,28 +122,11 @@ export function stringAmountToDecimal(amount: string) {
 export function parseAmountFromString(amount_raw: string): Decimal {
     // If there is a colon in the value, then the amount is going to be on the
     // left hand side.
-    const part1 = amount_raw.split(":")[0]
-
-    // There can be at most one 'e' in the value, at the beginning.
-    const count = part1.split("e").length - 1
-    if (count == 0) {
-        return new Decimal(part1)
-    } else if (count <= 1) {
-        // should be at the beginning
-        if (part1[0] == "e") {
-            // there needs to be an actual amount
-            if (part1 != "e") {
-                const part2 = part1.split("e")[1]
-                return new Decimal(part2)
-            } else {
-                throw new Error("Invalid amount format for webcash.")
-            }
-        } else {
-            throw new Error("Invalid amount format for webcash.")
-        }
-    } else {
-        throw new Error("Invalid amount format for webcash.")
+    var amount = amount_raw.split(":")[0]
+    if (amount[0] === 'e') {
+        amount = amount.slice(1);
     }
+    return new Decimal(amount);
 }
 
 // Take any kind of webcash and instantiate an object with the values specified

--- a/test.tsx
+++ b/test.tsx
@@ -74,6 +74,10 @@ test("parse amount from string", () => {
     expect(parseAmountFromString("e500")).toEqual(new Decimal(500));
     expect(parseAmountFromString("e1.05")).toEqual(new Decimal("1.05"));
 
+    expect(parseAmountFromString("e0.00000001")).toEqual(new Decimal("1E-8"));
+    expect(parseAmountFromString("e1E-8")).toEqual(new Decimal("1E-8"));
+    expect(parseAmountFromString("e1e-8")).toEqual(new Decimal("1E-8")); // See PR comment
+
     expect(parseAmountFromString("100:secret:feedbeef")).toEqual(new Decimal(100));
     expect(parseAmountFromString("e100:secret:feedbeef")).toEqual(new Decimal(100));
 


### PR DESCRIPTION
I don't necessarily expect this to be merged as it is now (the new function is likely too lax as it accepts binary/octal/...), but helps show the issue.

Currently the following doesn't work with the `master` version of `parseAmountFromString()` because of the second "e" in the input:
```
expect(parseAmountFromString("e1e-8")).toEqual(new Decimal("1E-8"));
```

However,
- `console.log(0.00000001)` prints `1e-8`
- `( new Decimal("1e8") ).equals( new Decimal("1E8") )` evaluates to `true`

So I guess it would be better if the code allows for both "E" and "e"? I can deal with this quirk on my end by passing a Decimal instead of a string to the Webcash library, but I thought it could be a recurring problem given JS prints lowercase by default.